### PR TITLE
Make broken packs more accurate

### DIFF
--- a/en-us/resource-pack-issues.md
+++ b/en-us/resource-pack-issues.md
@@ -50,6 +50,20 @@ If your resource pack's entities are supported but are still not displayed corre
 
 See also: [a list of resource packs that should work (cem#9)](https://github.com/dorianpb/cem/issues/9)
 
+### Broken paths
+
+**NOTE:** This applies **only** on FO versions 3.3.0 and below.
+
+If you see this message while activating a resource pack:
+
+![Contains broken paths](https://i.ibb.co/26cMtqr/Screenshot-20211116-191457.png)
+
+This means the resource pack maker is **using spaces or other non-standard characters** in the file or folder names.
+
+If this is the case, the modpack will warn you and allow overriding it, but note that various glitches may occur (miscolored or invisible blocks, lightning issues, broken textures...).
+
+To fix that, please tell the resource pack maker to only use the following characters in file/folder names: `a-z0-9/._-`.
+
 ### Invisible blocks
 
 This may occur when the pack is using broken paths and is trying to change the models of some blocks, like chests.
@@ -78,18 +92,3 @@ Beds:
 1. Close the game
 2. Remove or disable the Better Beds mod from your launcher.
 3. Start the game and see if it is fixed.
-
-### Broken paths
-
-**NOTE:** This applies **only** on FO versions 2.7.1 and below.
-
-If you see this message while activating a resource pack:
-
-![Contains broken paths](https://i.ibb.co/26cMtqr/Screenshot-20211116-191457.png)
-
-This means the resource pack maker is **using spaces or other non-standard characters** in the file or folder names.
-
-If this is the case, the modpack will warn you and allow overriding it, but note that various glitches may occur (miscolored or invisible blocks, lightning issues, broken textures...).
-
-To fix that, please tell the resource pack maker to only use the following characters in file/folder names: `a-z0-9/._-`.
-

--- a/en-us/resource-pack-issues.md
+++ b/en-us/resource-pack-issues.md
@@ -78,3 +78,18 @@ Beds:
 1. Close the game
 2. Remove or disable the Better Beds mod from your launcher.
 3. Start the game and see if it is fixed.
+
+### Broken paths
+
+**NOTE:** This applies **only** on FO versions 2.7.1 and below.
+
+If you see this message while activating a resource pack:
+
+![Contains broken paths](https://i.ibb.co/26cMtqr/Screenshot-20211116-191457.png)
+
+This means the resource pack maker is **using spaces or other non-standard characters** in the file or folder names.
+
+If this is the case, the modpack will warn you and allow overriding it, but note that various glitches may occur (miscolored or invisible blocks, lightning issues, broken textures...).
+
+To fix that, please tell the resource pack maker to only use the following characters in file/folder names: `a-z0-9/._-`.
+

--- a/en-us/resource-pack-issues.md
+++ b/en-us/resource-pack-issues.md
@@ -50,18 +50,6 @@ If your resource pack's entities are supported but are still not displayed corre
 
 See also: [a list of resource packs that should work (cem#9)](https://github.com/dorianpb/cem/issues/9)
 
-### Broken paths
-
-If you see this message while activating a resource pack:
-
-![Contains broken paths](https://i.ibb.co/26cMtqr/Screenshot-20211116-191457.png)
-
-This means the resource pack maker is **using spaces or other non-standard characters** in the file or folder names.
-
-If this is the case, the modpack will warn you and allow overriding it, but note that various glitches may occur (miscolored or invisible blocks, lightning issues, broken textures...).
-
-To fix that, please tell the resource pack maker to only use the following characters in file/folder names: `a-z0-9/._-`.
-
 ### Invisible blocks
 
 This may occur when the pack is using broken paths and is trying to change the models of some blocks, like chests.


### PR DESCRIPTION
I know this is showed by CIT Resewed, but ETF has fixed that, and the error does not appear.

([Here](https://www.curseforge.com/minecraft/mc-mods/entity-texture-features-fabric/files/3723195), on `added a setting to allow illegal characters in texture files like spaces and capitals (Optifine parity)`)