### PR TITLE
Bump checkout to v3, Ubuntu to 22.04.

### DIFF
--- a/.github/workflows/git-repo-sync.yml
+++ b/.github/workflows/git-repo-sync.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   sync-bitbucket:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Git Repo Sync - BitBucket
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: wangchucheng/git-repo-sync@v0.1.0


### PR DESCRIPTION
* Bumps Ubuntu version to 22.04 LTS,
* Bumps the checkout system to version 3.

While this doesn't change tons of things - It is suggested to upgrade so that the workflow is up-to-date rather than behind in a two-year gap or beyond that.