### PR TITLE
Add instructions for GDLauncher Carbon.

### DIFF
--- a/adding-more-mods.md
+++ b/adding-more-mods.md
@@ -59,6 +59,19 @@ Method 2:
 6. Once downloaded, copy the JAR file to the pack's "mods" folder.
 7. Run the game as usual. You should now have the new mod(s) installed!
 
+### GDLauncher Carbon
+
+1. Open GDLauncher Carbon
+2. Click on Fabulously Optimized
+3. Click `Settings`
+4. Click `🔒 Unlock`
+    * **Do NOT click `× Unpair`!** If you do that, you'll have to download a new instance of FO and manually move worlds/resource packs/etc over.
+5. Click `Mods`
+6. Click `Add Mod`
+7. Search for the mod you want
+8. Click `DOWNLOAD LATEST`
+9. Go back to `Library` and run the game as usual. You should now have the new mod(s)installed.
+
 ### Minecraft Launcher (vanilla)
 
 1. Open Minecraft Launcher, click on `Installations`
@@ -68,10 +81,6 @@ Method 2:
 5. Click `⤓` on the latest version that is compatible with Fabric and your Minecraft version
 6. Once downloaded, copy the JAR file to the pack's "mods" folder.
 7. Run the game as usual. You should now have the new mod(s) installed!
-
-### GDLauncher
-
-No longer supported. [Please migrate to Prism Launcher.](install-instructions.md#gdlauncher)
 
 ### Other hints
 

--- a/disabling-mods.md
+++ b/disabling-mods.md
@@ -55,6 +55,16 @@ There is currently no _easy_ way because the tool downloads missing mods back on
 
 Consider [switching to Prism Launcher instead,](install-instructions.md#prism-launcher) which also has a seamless modpack updater.
 
+### GDLauncher Carbon
+
+1. Open GDLauncher Carbon
+2. Click on Fabulously Optimized
+3. Click `Settings`
+4. Click `🔒 Unlock`
+    * **Do NOT click `× Unpair`!** If you do that, you'll have to download a new instance of FO and manually move worlds/resource packs/etc over.
+5. Click `Mods`
+6. Find the mod you need, toggle the knob.
+
 ### Minecraft Launcher (vanilla)
 
 1. Open Minecraft Launcher, click on `Installations`

--- a/install-instructions.md
+++ b/install-instructions.md
@@ -100,6 +100,13 @@ You need [Java 17 or higher](https://adoptium.net/) to play the game.
 
 </details>
 
+### [GDLauncher](https://gdlauncher.com/)
+
+1. Click `Modpacks`
+2. Select `Modrinth` tab from the left
+3. Click `Download Latest` from the Fabulously Optimized Listing
+4. Once installed, hover over the modpack icon and click the play icon to launch.
+
 ### [Minecraft Launcher](https://www.minecraft.net/en-us/download) (vanilla)
 
 For macOS or Linux [you need Java](https://adoptium.net/) to run the Fabric Installer.
@@ -148,27 +155,9 @@ A simple installer for vanilla launcher [is planned](https://github.com/Fabulous
 
 ### GDLauncher
 
-Due to technical limits and issues, GDLauncher is no longer supported. It is recommended to migrate to Prism Launcher:
+Due to technical limits and issues, GDLauncher is no longer supported. It is recommended to migrate to the new GDLauncher Carbon.
 
-1. [Install and run Prism Launcher](https://prismlauncher.org/)
-2. Click `Add Instance`
-3. Select `Modrinth` tab from the left
-4. Select "Fabulously Optimized"
-5. Click `OK`
-6. The modpack will now install.
-7. Once installed, click the `Folder` button on the left.
-8. Open GDLauncher
-9. Right click on your previously used instance → `Open Folder`
-10. Copy the important files and folders over:
-    * `saves` for your local worlds
-    * `resourcepacks`, if you use any (do not copy old versions of FO-bundled packs though)
-    * `screenshots`
-    * `servers.dat` for your multiplayer servers
-    * `options.txt`, if you want to keep your vanilla option changes
-11. Launch the instance on Prism and confirm everything is correct
-12. Uninstall GDLauncher
-
-[GDLauncher Carbon](https://gdlauncher.com/en/blog/curseforge-partnership-announcement/) may be supported in the future.
+To be continued...
 
 ### Pojav Launcher
 

--- a/update-instructions.md
+++ b/update-instructions.md
@@ -102,6 +102,10 @@ If there is a new Minecraft version:
 
 </details>
 
+### GDLauncher Carbon
+
+To be continued...
+
 ### Minecraft Launcher (vanilla)
 
 Currently the only way to update is to "reinstall" the pack. Consider installing a different launcher for a smoother upgrade experience.


### PR DESCRIPTION
Description: This PR adds instructions for the upcoming GDLauncher Carbon.

Note: I did not do migration isnturctions as I cannot run the old GDLauncher. I also have not done the update instructions as the current system for updating modpack is very buggy, but this has been reported to the devs.