### PR TITLE
Add friendly name to checkout, Update Ubuntu to 24.04

### DIFF
--- a/.github/workflows/git-repo-sync.yml
+++ b/.github/workflows/git-repo-sync.yml
@@ -8,10 +8,11 @@ on:
 jobs:
   sync-bitbucket:
     if: github.repository_owner == 'Fabulously-Optimized'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Git Repo Sync - BitBucket
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout Repository
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: wangchucheng/git-repo-sync@v0.1.0


### PR DESCRIPTION
1. Syncs the Ubuntu update from [this PR](https://github.com/Fabulously-Optimized/fabulously-optimized/pull/842),
2. Adds friendly name to the checkout step to clarify on what is meant to happen.

Extra note: This PR can be copied over to the `github.io` repo as it's the same thing there.