### PR TITLE
deps(ci): bump actions/checkout to v7.0.0

### DIFF
--- a/.github/workflows/git-repo-sync.yml
+++ b/.github/workflows/git-repo-sync.yml
@@ -15,7 +15,7 @@ jobs:
     name: Git Repo Sync - BitBucket
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
         persist-credentials: false


### PR DESCRIPTION
**Copilot summary:**
This pull request updates the GitHub Actions workflow to use a newer version of the `actions/checkout` action for the BitBucket sync job.

Workflow dependency update:

* Updated the `actions/checkout` action from version `v6.0.2` to `v7.0.0` in the `.github/workflows/git-repo-sync.yml` file to ensure compatibility with the latest features and security improvements.